### PR TITLE
Don't interpret integer command data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [2.0.0]
 ### Added
 - CHANGELOG.md
 
 ### Changed
 - Add GD3 character encoding information to README.md
+- Don't interpret integer command data, leave the raw command data intact
 
 ## [1.1.0] - 2016-01-20
 ### Added
@@ -17,5 +18,5 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - All project files (initial release)
 
-[Unreleased]: https://github.com/cdodd/vgmparse/compare/1.1.0...HEAD
+[2.0.0]: https://github.com/cdodd/vgmparse/compare/1.1.0...2.0.0
 [1.1.0]: https://github.com/cdodd/vgmparse/compare/1.0.0...1.1.0

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ The VGM commands are available as a `list` of `dict`s in the variable
 [{'data': '(\x00', 'command': 'R'}, {'data': '(\x04', 'command': 'R'}, {'data': '(\x01', 'command': 'R'}]
 ```
 
-If a command does not have have any data then `data` will be `None`. Commands
-that have integer data (`0x61`, `0xe0`) are interpreted for you.
+If a command does not have have any data then `data` will be `None`.
 
 **Note:** `command_list` will not include any data block commands as the data
 block is parsed out for you.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='vgmparse',
-    version='1.1.0',
+    version='2.0.0',
     description='VGM (Video Game Music) file parser',
     url='https://github.com/cdodd/vgmparse',
     author='Craig Dodd',

--- a/vgmparse/__init__.py
+++ b/vgmparse/__init__.py
@@ -103,7 +103,7 @@ class Parser:
             elif command == b'\x61':
                 self.command_list.append({
                     'command': command,
-                    'data': struct.unpack('<H', self.data.read(2))[0],
+                    'data': self.data.read(2),
                 })
 
             # 0x62 - Wait 735 samples (60th of a second)
@@ -139,7 +139,7 @@ class Parser:
             elif command == b'\xe0':
                 self.command_list.append({
                     'command': command,
-                    'data': struct.unpack('<I', self.data.read(4))[0],
+                    'data': self.data.read(4),
                 })
 
         # Seek back to the original position in the VGM data


### PR DESCRIPTION
Clients of this module may find it more convenient to use the raw integer command data, rather than having it interpreted (e.g. when streaming data to another device).

If a client needs to interpret the data it is trivial to do using struct.unpack.
